### PR TITLE
Use package babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simple HTML5 drag-drop zone with React.js",
   "main": "lib/index.js",
   "scripts": {
-    "build": "babel ./src/index.js --out-file ./lib/index.js",
+    "build": "./node_modules/.bin/babel ./src/index.js --out-file ./lib/index.js",
     "prepublish": "npm run lint && npm test && npm run build",
     "test": "./node_modules/.bin/mocha --require ./mocha-environment.js './src/test.js'",
     "lint": "eslint ./src",


### PR DESCRIPTION
The global babel may not be compatible. (For instance, the library is not currently compatible with babel 6 because of the `.babelrc` reference to `"stage": 0`).