### PR TITLE
Update build environment (#112)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "stage": 0,
-  "loose": "all"
+  "presets": ["es2015", "react", "stage-0"],
+  "plugins": ["add-module-exports"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 
 # Generated files
 lib
+dist
 
 #IDE
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ logs
 node_modules
 
 # Generated files
-lib
 dist
 
 #IDE

--- a/mocha-environment.js
+++ b/mocha-environment.js
@@ -1,5 +1,5 @@
 // import es6
-require('babel/register');
+require('babel-core/register');
 
 // jsdom
 var jsdom = require('jsdom');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simple HTML5 drag-drop zone with React.js",
   "main": "lib/index.js",
   "scripts": {
-    "build": "babel ./src --out-dir ./lib",
+    "build": "babel ./src --out-dir ./lib && webpack && uglifyjs ./dist/react-dropzone.js --compress --mangle --output ./dist/react-dropzone.min.js",
     "prepublish": "npm run lint && npm test && npm run build",
     "test": "mocha --require ./mocha-environment.js './src/test.js'",
     "lint": "eslint ./src",
@@ -42,8 +42,13 @@
     "attr-accept": "^1.0.3"
   },
   "devDependencies": {
-    "babel": "^5.8.29",
+    "babel-cli": "^6.4.5",
+    "babel-core": "^6.4.5",
     "babel-eslint": "^4.1.6",
+    "babel-plugin-add-module-exports": "^0.1.2",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
+    "babel-preset-stage-0": "^6.3.13",
     "chai": "^3.4.1",
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "^2.1.1",
@@ -55,6 +60,8 @@
     "react-addons-test-utils": "^0.14.3",
     "react-dom": "^0.14.3",
     "react-testutils-additions": "^0.2.0",
-    "sinon": "^1.17.2"
+    "sinon": "^1.17.2",
+    "uglifyjs": "^2.4.10",
+    "webpack": "^1.12.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "react-dropzone",
   "version": "3.3.2",
   "description": "Simple HTML5 drag-drop zone with React.js",
-  "main": "lib/index.js",
+  "main": "dist/index.js",
   "scripts": {
-    "build": "babel ./src --out-dir ./lib && webpack && uglifyjs ./dist/react-dropzone.js --compress --mangle --output ./dist/react-dropzone.min.js",
+    "build": "webpack",
     "prepublish": "npm run lint && npm test && npm run build",
     "test": "mocha --require ./mocha-environment.js './src/test.js'",
     "lint": "eslint ./src",
@@ -45,6 +45,7 @@
     "babel-cli": "^6.4.5",
     "babel-core": "^6.4.5",
     "babel-eslint": "^4.1.6",
+    "babel-loader": "^6.2.2",
     "babel-plugin-add-module-exports": "^0.1.2",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
@@ -61,7 +62,6 @@
     "react-dom": "^0.14.3",
     "react-testutils-additions": "^0.2.0",
     "sinon": "^1.17.2",
-    "uglifyjs": "^2.4.10",
     "webpack": "^1.12.11"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,14 +1,12 @@
-{
-  module.exports = {
-    entry: "./lib/index.js",
-    output: {
-      path: __dirname,
-      filename: "./dist/react-dropzone.js",
-      libraryTarget: "var",
-      library: "Dropzone"
-    },
-    externals: {
-      "react": "React"
-    }
-  }
+module.exports = {
+	entry: "./lib/index.js",
+	output: {
+		path: __dirname,
+		filename: "./dist/react-dropzone.js",
+		libraryTarget: "var",
+		library: "Dropzone"
+	},
+	externals: {
+		"react": "React"
+	}
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,10 +18,6 @@ module.exports = {
                 ],
                 test: /\.js$/,
                 loader: 'babel-loader',
-                query: {
-                    presets: ['es2015','react','stage-0'],
-                    plugins: ['add-module-exports']
-                }
             }
         ]  
     },
@@ -35,7 +31,7 @@ module.exports = {
     plugins: [
         new webpack.optimize.UglifyJsPlugin({
             compress: {
-                // does this actually do anything?
+                // does this actually compress anything?
                 warnings: false
             }
         }),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,12 +1,43 @@
+var webpack = require('webpack');
+var path = require('path');
+
 module.exports = {
-	entry: "./lib/index.js",
+	entry: "./src/index.js",
+    devtool: "source-map",
 	output: {
 		path: __dirname,
 		filename: "./dist/react-dropzone.js",
-		libraryTarget: "var",
+		libraryTarget: "umd",
 		library: "Dropzone"
 	},
+    module: {
+        loaders: [
+            {
+                include: [
+                    path.resolve(__dirname,"src"),
+                ],
+                test: /\.js$/,
+                loader: 'babel-loader',
+                query: {
+                    presets: ['es2015','react','stage-0'],
+                    plugins: ['add-module-exports']
+                }
+            }
+        ]  
+    },
+    resolve: {
+        // Can require('file') instead of require('file.js') etc.
+        extensions: ['','.js','.json']
+    },
 	externals: {
 		"react": "React"
-	}
+	},
+    plugins: [
+        new webpack.optimize.UglifyJsPlugin({
+            compress: {
+                // does this actually do anything?
+                warnings: false
+            }
+        }),
+    ]
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,37 +3,37 @@ var path = require('path');
 
 module.exports = {
 	entry: "./src/index.js",
-    devtool: "source-map",
+	devtool: "source-map",
 	output: {
-		path: __dirname,
-		filename: "./dist/react-dropzone.js",
+		path: __dirname + '/dist/',
+		filename: "index.js",
 		libraryTarget: "umd",
 		library: "Dropzone"
 	},
-    module: {
-        loaders: [
-            {
-                include: [
-                    path.resolve(__dirname,"src"),
-                ],
-                test: /\.js$/,
-                loader: 'babel-loader',
-            }
-        ]  
-    },
-    resolve: {
-        // Can require('file') instead of require('file.js') etc.
-        extensions: ['','.js','.json']
-    },
-	externals: {
-		"react": "React"
+	module: {
+		loaders: [
+			{
+				include: [
+					path.resolve(__dirname,"src"),
+				],
+				test: /\.js$/,
+				loader: 'babel-loader',
+			}
+		]
 	},
-    plugins: [
-        new webpack.optimize.UglifyJsPlugin({
-            compress: {
-                // does this actually compress anything?
-                warnings: false
-            }
-        }),
-    ]
+	resolve: {
+		// Can require('file') instead of require('file.js') etc.
+		extensions: ['','.js','.json']
+	},
+	externals: {
+		"react": "React",
+	},
+	plugins: [
+		new webpack.optimize.UglifyJsPlugin({
+			compress: {
+				// does this actually compress anything?
+				warnings: false
+			}
+		}),
+	]
 };


### PR DESCRIPTION
Tweaked the build environment:

* Upgraded to babel6.
* Removed the "loose" parameter in babel, since it's not recommended.
Testing shows no  behaviour difference in the resulting code.
* Added a webpack step to generate a ES5 and <script> friendly module
(webpack is also a devDependency now).
* Added a uglifyjs step to minify the bundle (uglifyjs also a
devDependency now)

react-dropzone can now be hosted on a CDN and used directly in a
<script> tag, although the package attr-accept must also be referenced.
Maybe bake it into the code with webpack?