### PR TITLE
Fixing an issue when the droppedFiles array is empty

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,7 @@ class Dropzone extends React.Component {
     const droppedFiles = e.dataTransfer ? e.dataTransfer.files : e.target.files;
     const files = [];
 
-    if (droppedFiles.length === 0) {
+    if (!droppedFiles || (droppedFiles.length === 0)) {
       return;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -82,10 +82,13 @@ class Dropzone extends React.Component {
     });
 
     const droppedFiles = e.dataTransfer ? e.dataTransfer.files : e.target.files;
-    const max = this.props.multiple ? droppedFiles.length : 1;
     const files = [];
 
-    for (let i = 0; i < max; i++) {
+    if (droppedFiles.length === 0) {
+      return;
+    }
+
+    for (let i = 0; i < droppedFiles.length; i++) {
       const file = droppedFiles[i];
       // We might want to disable the preview creation to support big files
       if (!this.props.disablePreview) {

--- a/src/test.js
+++ b/src/test.js
@@ -40,6 +40,15 @@ describe('Dropzone', () => {
     expect(dropSpy.firstCall.args[0][0]).to.have.property('preview');
   });
 
+  it('should not call onDrop when the droppedFiles array is empty', () => {
+    const dropSpy = spy();
+    const dropzone = TestUtils.renderIntoDocument(<Dropzone onDrop={dropSpy}><div className="dropzone-content">some content</div></Dropzone>);
+    const content = TestUtils.findRenderedDOMComponentWithClass(dropzone, 'dropzone-content');
+
+    TestUtils.Simulate.drop(content, { dataTransfer: { files: [] } });
+    expect(dropSpy.callCount).to.equal(0);
+  });
+
   describe('ref', () => {
     it('sets ref properly', () => {
       const dropzone = TestUtils.renderIntoDocument(<Dropzone/>);


### PR DESCRIPTION
I'm using both [Sortable](https://github.com/RubaXa/Sortable) and [react-dropzone](https://github.com/okonet/react-dropzone) in the web interface, and made the whole body a dropzone like below:

![](https://dl.dropboxusercontent.com/u/7076728/cnc-dropzone.png)

However, when I drag and drop sortable widgets only within the UI, but not dragging files from somewhere else, it will still invoke react-dropzone's `onDrop` method, and generated an error:
```
Uncaught TypeError: Cannot set property 'preview' of undefined
```

Since there are no files, it should stop proceeding and return immediately if the `droppedFiles` array is empty.