### PR TITLE
Add more MIME type examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ Features
 
 - `disableClick` - Clicking the `<Dropzone>` brings up the browser file picker. To disable, set to `true`.
 - `multiple` - To accept only a single file, set this to `false`.
-- `accept` - Filters the file types that are valid. It should have a valid MIME type according to [input element](http://www.w3.org/TR/html-markup/input.file.html), e.g. accept="application/pdf".
+- `accept` - Filters the file types that are valid. It should have a valid MIME type according to [input element](http://www.w3.org/TR/html-markup/input.file.html), for example:
+  * `application/pdf`
+  * `image/*`
+  * `audio/aiff,audio/midi`
 
 To show a preview of the dropped file while it uploads, use the `file.preview` property. Use `<img src={file.preview} />` to display a preview of the image dropped.
 You can disable the creation of the preview (for example if you drop big files) by setting the `disablePreview` prop to `true`.


### PR DESCRIPTION
They can be a single MIME type or a comma delimited list. It's not something that I could easily find without some digging, so I thought it would be useful to provide this shortcut info right away.

Closes #141.