### PR TITLE
fix #159 require 'React' instead of 'react'

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = {
     extensions: ['', '.js', '.json']
   },
   externals: {
-    react: 'React'
+    react: 'react'
   },
   plugins: []
 };


### PR DESCRIPTION
fix issue `Cannot find module "React"`

https://travis-ci.org/okonet/react-dropzone/builds/120584465#L205