### PR TITLE
updated react dep to v15

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "react": "^0.14.0"
+    "react": "^0.14.0 || ^15.0.0"
   },
   "dependencies": {
     "attr-accept": "^1.0.3"
@@ -59,10 +59,10 @@
     "jsdom": "^7.2.0",
     "mocha": "^2.3.4",
     "pre-commit": "^1.1.2",
-    "react": "^0.14.3",
-    "react-addons-test-utils": "^0.14.3",
-    "react-dom": "^0.14.3",
-    "react-testutils-additions": "^0.2.0",
+    "react": "^15.0.1",
+    "react-addons-test-utils": "^15.0.1",
+    "react-dom": "^15.0.1",
+    "react-testutils-additions": "^15.0.0",
     "rimraf": "^2.5.2",
     "sinon": "^1.17.2",
     "webpack": "^1.12.11"


### PR DESCRIPTION
closes #165

- tests pass with react v15
- a `react-dropzone` component I have in one of my apps works with react v15