### PR TITLE
Remove more custom properties before passing them to wrapper element

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -212,9 +212,10 @@ class Dropzone extends React.Component {
       inputAttributes.name = name;
     }
 
+    // Remove custom properties before passing them to the wrapper div element
+    const customProps = ['disablePreview', 'disableClick', 'onDropAccepted', 'onDropRejected'];
     const divProps = { ...props };
-    delete divProps.disablePreview;
-    delete divProps.disableClick;
+    customProps.forEach(prop => delete divProps[prop]);
 
     return (
       <div


### PR DESCRIPTION
A follow-up of: https://github.com/okonet/react-dropzone/pull/194