### PR TITLE
Conditionally skip test based on React version

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "react-dom": "^15.2.0",
     "react-testutils-additions": "^15.0.0",
     "rimraf": "^2.5.2",
+    "semver": "^5.3.0",
     "sinon": "^1.17.4",
     "webpack": "^1.13.1"
   }

--- a/src/test.js
+++ b/src/test.js
@@ -4,7 +4,9 @@ import React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import TestUtils from 'react-testutils-additions';
+import semver from 'semver';
 const Dropzone = require(process.env.NODE_ENV === 'production' ? '../dist/index' : './index');
+const itConditional = semver.satisfies(React.version, '>=15.2.1') ? it : it.skip;
 
 describe('Dropzone', () => {
 
@@ -276,7 +278,7 @@ describe('Dropzone', () => {
         .to.have.length(0);
     });
 
-    it.skip('does not apply the name prop if name is falsey', () => {
+    itConditional('does not apply the name prop if name is falsey', () => {
       const component = TestUtils.renderIntoDocument(
         <Dropzone className="my-dropzone" name="" />
       );


### PR DESCRIPTION
React [issue #7198](https://github.com/facebook/react/issues/7198) was fixed in [React 15.2.1](https://github.com/facebook/react/blob/master/CHANGELOG.md#1521-july-8-2016), so it's safe to run the `.skip`ed test. This will check the React version and run the test if the user is running React 15.2.1 or higher.