### PR TITLE
Unknown prop `maxSize` / `minSize` on <div> tag.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -217,7 +217,7 @@ class Dropzone extends React.Component {
     }
 
     // Remove custom properties before passing them to the wrapper div element
-    const customProps = ['disablePreview', 'disableClick', 'onDropAccepted', 'onDropRejected'];
+    const customProps = ['disablePreview', 'disableClick', 'onDropAccepted', 'onDropRejected', 'maxSize', 'minSize'];
     const divProps = { ...props };
     customProps.forEach(prop => delete divProps[prop]);
 


### PR DESCRIPTION
This PR removes maxSize and minSize from wrapping `<div>`.

The contribution in #202 missed adding `maxSize` and `minSize` to the [list of `customProps`](https://github.com/okonet/react-dropzone/blob/c6f072a1317474b907f06379606b5ae826b9cac1/src/index.js#L220). Due to that React is throwing a warning:

`Warning: Unknown prop `maxSize` on <div> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop`

This PR should fix that.