### PR TITLE
Separate accepted and rejected files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ npm install --save react-dropzone@2.x
 Usage
 =====
 
-Simply `require('react-dropzone')` and specify an `onDrop` method that accepts an array of dropped files.
+Simply `require('react-dropzone')` and specify an `onDrop` method which accepts two arguments. The first argument represents the accepted files and the second argument the rejected files.
+
+The `onDrop` method gets always called if a file was uploaded, regardless if it was accepted or rejected. The library provides two additional methods named `onDropAccepted` and `onDropRejected`. The `onDropAccepted` method will be called if all dropped files were accepted and the `onDropRejected` method will be called if any of the dropped files was rejected.
 
 By default, the component picks up some default styling to get you started. You can customize `<Dropzone>` by specifying a `style` and `activeStyle` which is applied when a file is dragged over the zone. You can also specify `className` and `activeClassName` if you would rather style using CSS.
 
@@ -46,8 +48,9 @@ var React = require('react');
 var Dropzone = require('react-dropzone');
 
 var DropzoneDemo = React.createClass({
-    onDrop: function (files) {
-      console.log('Received files: ', files);
+    onDrop: function (acceptedFiles, rejectedFiles) {
+      console.log('Accepted files: ', acceptedFiles);
+      console.log('Rejected files: ', rejectedFiles);
     },
 
     render: function () {
@@ -92,9 +95,9 @@ var DropzoneDemo = React.createClass({
         };
     },
 
-    onDrop: function (files) {
+    onDrop: function (acceptedFiles) {
       this.setState({
-        files: files
+        files: acceptedFiles
       });
     },
 
@@ -131,9 +134,9 @@ Using `react-dropzone` is similar to using a file form field, but instead of get
 Specifying the `onDrop` method, provides you with an array of [Files](https://developer.mozilla.org/en-US/docs/Web/API/File) which you can then send to a server. For example, with [SuperAgent](https://github.com/visionmedia/superagent) as a http/ajax library:
 
 ```javascript
-    onDrop: function(files){
+    onDrop: function(acceptedFiles){
         var req = request.post('/upload');
-        files.forEach((file)=> {
+        acceptedFiles.forEach((file)=> {
             req.attach(file.name, file);
         });
         req.end(callback);

--- a/src/test.js
+++ b/src/test.js
@@ -11,12 +11,22 @@ const itConditional = semver.satisfies(React.version, '>=15.2.1') ? it : it.skip
 describe('Dropzone', () => {
 
   let files = [];
+  let images = [];
 
   beforeEach(() => {
     files = [{
       name: 'file1.pdf',
       size: 1111,
       type: 'application/pdf'
+    }];
+    images = [{
+      name: 'cats.gif',
+      size: 1234,
+      type: 'image/gif'
+    }, {
+      name: 'dogs.jpg',
+      size: 2345,
+      type: 'image/jpeg'
     }];
   });
 
@@ -144,68 +154,77 @@ describe('Dropzone', () => {
     });
 
     it('applies the accept prop to the dropped files', () => {
-      const images = [{
-        name: 'cats.gif',
-        size: 1234,
-        type: 'image/gif'
-      }, {
-        name: 'dogs.jpg',
-        size: 2345,
-        type: 'image/jpeg'
-      }];
       const dropSpy = spy();
+      const dropAcceptedSpy = spy();
+      const dropRejectedSpy = spy();
       const dropzone = TestUtils.renderIntoDocument(
-        <Dropzone onDrop={dropSpy} accept="image/*">
+        <Dropzone onDrop={dropSpy} onDropAccepted={dropAcceptedSpy} onDropRejected={dropRejectedSpy} accept="image/*">
           <div className="dropzone-content">some content</div>
         </Dropzone>
       );
       const content = TestUtils.findRenderedDOMComponentWithClass(dropzone, 'dropzone-content');
 
       TestUtils.Simulate.drop(content, { dataTransfer: { files } });
-      expect(dropSpy.callCount).to.equal(0);
+      expect(dropSpy.callCount).to.equal(1);
+      expect(dropSpy.firstCall.args[0]).to.have.length(0);
+      expect(dropSpy.firstCall.args[1]).to.have.length(1);
+
+      expect(dropAcceptedSpy.callCount).to.equal(0);
+
+      expect(dropRejectedSpy.callCount).to.equal(1);
+      expect(dropRejectedSpy.firstCall.args[0]).to.have.length(1);
+    });
+
+    it('applies the accept prop to the dropped images', () => {
+      const dropSpy = spy();
+      const dropAcceptedSpy = spy();
+      const dropRejectedSpy = spy();
+      const dropzone = TestUtils.renderIntoDocument(
+        <Dropzone onDrop={dropSpy} onDropAccepted={dropAcceptedSpy} onDropRejected={dropRejectedSpy} accept="image/*">
+          <div className="dropzone-content">some content</div>
+        </Dropzone>
+      );
+      const content = TestUtils.findRenderedDOMComponentWithClass(dropzone, 'dropzone-content');
+
       TestUtils.Simulate.drop(content, { dataTransfer: { files: images } });
       expect(dropSpy.callCount).to.equal(1);
       expect(dropSpy.firstCall.args[0]).to.have.length(2);
+      expect(dropSpy.firstCall.args[1]).to.have.length(0);
+
+      expect(dropAcceptedSpy.callCount).to.equal(1);
+      expect(dropAcceptedSpy.firstCall.args[0]).to.have.length(2);
+
+      expect(dropRejectedSpy.callCount).to.equal(0);
     });
 
-    it('accepts all dropped files when no accept prop is specified', () => {
-      const images = [{
-        name: 'cats.gif',
-        size: 1234,
-        type: 'image/gif'
-      }, {
-        name: 'dogs.jpg',
-        size: 2345,
-        type: 'image/jpeg'
-      }];
+    it('accepts all dropped files and images when no accept prop is specified', () => {
       const dropSpy = spy();
+      const dropAcceptedSpy = spy();
+      const dropRejectedSpy = spy();
       const dropzone = TestUtils.renderIntoDocument(
-        <Dropzone onDrop={dropSpy}>
+        <Dropzone onDrop={dropSpy} onDropAccepted={dropAcceptedSpy} onDropRejected={dropRejectedSpy}>
           <div className="dropzone-content">some content</div>
         </Dropzone>
       );
       const content = TestUtils.findRenderedDOMComponentWithClass(dropzone, 'dropzone-content');
 
-      TestUtils.Simulate.drop(content, { dataTransfer: { files } });
+      TestUtils.Simulate.drop(content, { dataTransfer: { files: files.concat(images) } });
       expect(dropSpy.callCount).to.equal(1);
-      TestUtils.Simulate.drop(content, { dataTransfer: { files: images } });
-      expect(dropSpy.callCount).to.equal(2);
-      expect(dropSpy.secondCall.args[0]).to.have.length(2);
+      expect(dropSpy.firstCall.args[0]).to.have.length(3);
+      expect(dropSpy.firstCall.args[1]).to.have.length(0);
+
+      expect(dropAcceptedSpy.callCount).to.equal(1);
+      expect(dropAcceptedSpy.firstCall.args[0]).to.have.length(3);
+
+      expect(dropRejectedSpy.callCount).to.equal(0);
     });
 
     it('applies the maxSize prop to the dropped files', () => {
-      const images = [{
-        name: 'cats.gif',
-        size: 1234,
-        type: 'image/gif'
-      }, {
-        name: 'dogs.jpg',
-        size: 2345,
-        type: 'image/jpeg'
-      }];
       const dropSpy = spy();
+      const dropAcceptedSpy = spy();
+      const dropRejectedSpy = spy();
       const dropzone = TestUtils.renderIntoDocument(
-        <Dropzone onDrop={dropSpy} maxSize={1111}>
+        <Dropzone onDrop={dropSpy} onDropAccepted={dropAcceptedSpy} onDropRejected={dropRejectedSpy} maxSize={1111}>
           <div className="dropzone-content">some content</div>
         </Dropzone>
       );
@@ -213,59 +232,101 @@ describe('Dropzone', () => {
 
       TestUtils.Simulate.drop(content, { dataTransfer: { files } });
       expect(dropSpy.callCount).to.equal(1);
+      expect(dropSpy.firstCall.args[0]).to.have.length(1);
+      expect(dropSpy.firstCall.args[1]).to.have.length(0);
+
+      expect(dropAcceptedSpy.callCount).to.equal(1);
+      expect(dropAcceptedSpy.firstCall.args[0]).to.have.length(1);
+
+      expect(dropRejectedSpy.callCount).to.equal(0);
+    });
+
+    it('applies the maxSize prop to the dropped images', () => {
+      const dropSpy = spy();
+      const dropAcceptedSpy = spy();
+      const dropRejectedSpy = spy();
+      const dropzone = TestUtils.renderIntoDocument(
+        <Dropzone onDrop={dropSpy} onDropAccepted={dropAcceptedSpy} onDropRejected={dropRejectedSpy} maxSize={1111}>
+          <div className="dropzone-content">some content</div>
+        </Dropzone>
+      );
+      const content = TestUtils.findRenderedDOMComponentWithClass(dropzone, 'dropzone-content');
+
       TestUtils.Simulate.drop(content, { dataTransfer: { files: images } });
       expect(dropSpy.callCount).to.equal(1);
-      expect(dropSpy.firstCall.args[0]).to.have.length(1);
+      expect(dropSpy.firstCall.args[0]).to.have.length(0);
+      expect(dropSpy.firstCall.args[1]).to.have.length(2);
+
+      expect(dropAcceptedSpy.callCount).to.equal(0);
+
+      expect(dropRejectedSpy.callCount).to.equal(1);
+      expect(dropRejectedSpy.firstCall.args[0]).to.have.length(2);
     });
 
     it('applies the minSize prop to the dropped files', () => {
-      const images = [{
-        name: 'cats.gif',
-        size: 1234,
-        type: 'image/gif'
-      }, {
-        name: 'dogs.jpg',
-        size: 2345,
-        type: 'image/jpeg'
-      }];
       const dropSpy = spy();
+      const dropAcceptedSpy = spy();
+      const dropRejectedSpy = spy();
       const dropzone = TestUtils.renderIntoDocument(
-        <Dropzone onDrop={dropSpy} minSize={1112}>
+        <Dropzone onDrop={dropSpy} onDropAccepted={dropAcceptedSpy} onDropRejected={dropRejectedSpy} minSize={1112}>
           <div className="dropzone-content">some content</div>
         </Dropzone>
       );
       const content = TestUtils.findRenderedDOMComponentWithClass(dropzone, 'dropzone-content');
 
       TestUtils.Simulate.drop(content, { dataTransfer: { files } });
-      expect(dropSpy.callCount).to.equal(0);
+      expect(dropSpy.callCount).to.equal(1);
+      expect(dropSpy.firstCall.args[0]).to.have.length(0);
+      expect(dropSpy.firstCall.args[1]).to.have.length(1);
+
+      expect(dropAcceptedSpy.callCount).to.equal(0);
+
+      expect(dropRejectedSpy.callCount).to.equal(1);
+      expect(dropRejectedSpy.firstCall.args[0]).to.have.length(1);
+    });
+
+    it('applies the minSize prop to the dropped images', () => {
+      const dropSpy = spy();
+      const dropAcceptedSpy = spy();
+      const dropRejectedSpy = spy();
+      const dropzone = TestUtils.renderIntoDocument(
+        <Dropzone onDrop={dropSpy} onDropAccepted={dropAcceptedSpy} onDropRejected={dropRejectedSpy} minSize={1112}>
+          <div className="dropzone-content">some content</div>
+        </Dropzone>
+      );
+      const content = TestUtils.findRenderedDOMComponentWithClass(dropzone, 'dropzone-content');
+
       TestUtils.Simulate.drop(content, { dataTransfer: { files: images } });
       expect(dropSpy.callCount).to.equal(1);
       expect(dropSpy.firstCall.args[0]).to.have.length(2);
+      expect(dropSpy.firstCall.args[1]).to.have.length(0);
+
+      expect(dropAcceptedSpy.callCount).to.equal(1);
+      expect(dropAcceptedSpy.firstCall.args[0]).to.have.length(2);
+
+      expect(dropRejectedSpy.callCount).to.equal(0);
     });
 
-    it('accepts all dropped files when no size prop is specified', () => {
-      const images = [{
-        name: 'cats.gif',
-        size: 1234,
-        type: 'image/gif'
-      }, {
-        name: 'dogs.jpg',
-        size: 2345,
-        type: 'image/jpeg'
-      }];
+    it('accepts all dropped files and images when no size prop is specified', () => {
       const dropSpy = spy();
+      const dropAcceptedSpy = spy();
+      const dropRejectedSpy = spy();
       const dropzone = TestUtils.renderIntoDocument(
-        <Dropzone onDrop={dropSpy}>
+        <Dropzone onDrop={dropSpy} onDropAccepted={dropAcceptedSpy} onDropRejected={dropRejectedSpy}>
           <div className="dropzone-content">some content</div>
         </Dropzone>
       );
       const content = TestUtils.findRenderedDOMComponentWithClass(dropzone, 'dropzone-content');
 
-      TestUtils.Simulate.drop(content, { dataTransfer: { files } });
+      TestUtils.Simulate.drop(content, { dataTransfer: { files: files.concat(images) } });
       expect(dropSpy.callCount).to.equal(1);
-      TestUtils.Simulate.drop(content, { dataTransfer: { files: images } });
-      expect(dropSpy.callCount).to.equal(2);
-      expect(dropSpy.secondCall.args[0]).to.have.length(2);
+      expect(dropSpy.firstCall.args[0]).to.have.length(3);
+      expect(dropSpy.firstCall.args[1]).to.have.length(0);
+
+      expect(dropAcceptedSpy.callCount).to.equal(1);
+      expect(dropAcceptedSpy.firstCall.args[0]).to.have.length(3);
+
+      expect(dropRejectedSpy.callCount).to.equal(0);
     });
 
     it('applies the name prop to the child input', () => {


### PR DESCRIPTION
Currently it's not possible to distinguish between accepted and rejected files. The `onDrop` and the `onDropAccepted` functions gets only called with the accepted files. The `onDropRejected` function on the other side gets only called with the rejected files. But sometimes it's useful to react to both states.

This pull request implements the feature in a backward compatible way. The `onDrop` function gets the rejected files passed as second parameter. The `onDropAccepted` and the `onDropRejected` functions behaves the same.