### PR TITLE
Bind fileAccepted method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ class Dropzone extends React.Component {
     this.onDragOver = this.onDragOver.bind(this);
     this.onDrop = this.onDrop.bind(this);
     this.onFileDialogCancel = this.onFileDialogCancel.bind(this);
+    this.fileAccepted = this.fileAccepted.bind(this);
 
     this.state = {
       isDragActive: false,

--- a/src/test.js
+++ b/src/test.js
@@ -368,6 +368,17 @@ describe('Dropzone', () => {
       expect(dragStartSpy.callCount).to.equal(1);
     });
 
+    it('overrides onDragEnter', () => {
+      const dragEnterSpy = spy();
+      const component = TestUtils.renderIntoDocument(
+        <Dropzone id="drag-example" onDragEnter={dragEnterSpy} />
+      );
+      const content = TestUtils.find(component, '#drag-example')[0];
+
+      TestUtils.Simulate.dragEnter(content, { dataTransfer: { items: files } });
+      expect(dragEnterSpy.callCount).to.equal(1);
+    });
+
     it('do not invoke onCancel prop everytime document body receives focus', (done) => {
       const onCancelSpy = spy();
       TestUtils.renderIntoDocument(


### PR DESCRIPTION
You were right with the [bind issue](https://github.com/okonet/react-dropzone/pull/250#discussion_r82737534). I've looked on the wrong code. The `allFilesAccepted` method was not covered by a test. I've added one.