### PR TITLE
Add rejectionReason property to rejected files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -108,14 +108,26 @@ class Dropzone extends React.Component {
 
     for (let i = 0; i < max; i++) {
       const file = droppedFiles[i];
+
       // We might want to disable the preview creation to support big files
       if (!this.props.disablePreview) {
         file.preview = window.URL.createObjectURL(file);
       }
 
-      if (this.fileAccepted(file) && this.fileMatchSize(file)) {
+      let rejectionReason = null;
+
+      if (!this.fileAccepted(file)) {
+        rejectionReason = Dropzone.RejectionReason.InvalidFileType;
+      } else if (file.size > this.props.maxSize) {
+        rejectionReason = Dropzone.RejectionReason.AboveMaxSize;
+      } else if (file.size < this.props.minSize) {
+        rejectionReason = Dropzone.RejectionReason.BelowMinSize;
+      }
+
+      if (!rejectionReason) {
         acceptedFiles.push(file);
       } else {
+        file.rejectionReason = rejectionReason;
         rejectedFiles.push(file);
       }
     }
@@ -163,10 +175,6 @@ class Dropzone extends React.Component {
 
   fileAccepted(file) {
     return accepts(file, this.props.accept);
-  }
-
-  fileMatchSize(file) {
-    return file.size <= this.props.maxSize && file.size >= this.props.minSize;
   }
 
   allFilesAccepted(files) {
@@ -324,6 +332,12 @@ Dropzone.propTypes = {
   name: React.PropTypes.string, // name attribute for the input tag
   maxSize: React.PropTypes.number,
   minSize: React.PropTypes.number
+};
+
+Dropzone.RejectionReason = {
+  InvalidFileType: 1,
+  BelowMinSize: 2,
+  AboveMaxSize: 3
 };
 
 export default Dropzone;

--- a/src/test.js
+++ b/src/test.js
@@ -307,6 +307,43 @@ describe('Dropzone', () => {
       expect(dropRejectedSpy.callCount).to.equal(0);
     });
 
+    it('gives the reason for rejection', () => {
+      const dropSpy = spy();
+      const dropAcceptedSpy = spy();
+      const dropRejectedSpy = spy();
+      const dropzone = TestUtils.renderIntoDocument(
+        <Dropzone
+          onDrop={dropSpy}
+          onDropAccepted={dropAcceptedSpy}
+          onDropRejected={dropRejectedSpy}
+          minSize={1112}
+          maxSize={1235}
+          accept={"image/jpeg,application/pdf"}
+        >
+
+          <div className="dropzone-content">some content</div>
+        </Dropzone>
+      );
+
+      const content = TestUtils.findRenderedDOMComponentWithClass(dropzone, 'dropzone-content');
+
+      TestUtils.Simulate.drop(content, { dataTransfer: { files: files.concat(images) } });
+      expect(dropSpy.callCount).to.equal(1);
+      expect(dropSpy.firstCall.args[0]).to.have.length(0);
+      expect(dropSpy.firstCall.args[1]).to.have.length(3);
+
+      expect(dropSpy.firstCall.args[1][0].rejectionReason).to.equal(Dropzone.RejectionReason.BelowMinSize);
+      expect(dropSpy.firstCall.args[1][1].rejectionReason).to.equal(Dropzone.RejectionReason.InvalidFileType);
+      expect(dropSpy.firstCall.args[1][2].rejectionReason).to.equal(Dropzone.RejectionReason.AboveMaxSize);
+
+      expect(dropAcceptedSpy.callCount).to.equal(0);
+      expect(dropRejectedSpy.callCount).to.equal(1);
+
+      expect(dropRejectedSpy.firstCall.args[0][0].rejectionReason).to.equal(Dropzone.RejectionReason.BelowMinSize);
+      expect(dropRejectedSpy.firstCall.args[0][1].rejectionReason).to.equal(Dropzone.RejectionReason.InvalidFileType);
+      expect(dropRejectedSpy.firstCall.args[0][2].rejectionReason).to.equal(Dropzone.RejectionReason.AboveMaxSize);
+    });
+
     it('accepts all dropped files and images when no size prop is specified', () => {
       const dropSpy = spy();
       const dropAcceptedSpy = spy();


### PR DESCRIPTION
The rationale behind this is that I want to inform the user about the reason that a particular file was rejected. With this property I can listen to onDropRejected or onDrop, add the rejected files to my list, and display a tooltip giving the reason as translated text.

rejectionReason is only defined on rejected files. And has one of three possible values.

1 = InvalidFileType
2 = BelowMinSize
3 = AboveMaxSize

These values are listed on the RejectionReason enum which is a static property on the Dropzone class.

`
Dropzone.RejectionReason = {
  InvalidFileType: 1,
  BelowMinSize: 2,
  AboveMaxSize: 3
};
`

Thank you for the good work and I look forward to your feedback.
