### PR TITLE
remove dropEffect, as it causes errors in MS Edge/IE11

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,6 @@ class Dropzone extends React.Component {
   onDragOver(e) {
     e.preventDefault();
     e.stopPropagation();
-    
     try {
       e.dataTransfer.dropEffect = 'copy'; // eslint-disable-line no-param-reassign
     } catch (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -69,10 +69,10 @@ class Dropzone extends React.Component {
     e.preventDefault();
     e.stopPropagation();
     
-		try {
+    try {
       e.dataTransfer.dropEffect = 'copy'; // eslint-disable-line no-param-reassign		      
     } catch (e) {
-      
+      // continue regardless of error  
     }    
     
     return false;

--- a/src/index.js
+++ b/src/index.js
@@ -68,6 +68,13 @@ class Dropzone extends React.Component {
   onDragOver(e) {
     e.preventDefault();
     e.stopPropagation();
+    
+		try {
+      e.dataTransfer.dropEffect = 'copy'; // eslint-disable-line no-param-reassign		      
+    } catch (e) {
+      
+    }    
+    
     return false;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,6 @@ class Dropzone extends React.Component {
   onDragOver(e) {
     e.preventDefault();
     e.stopPropagation();
-    e.dataTransfer.dropEffect = 'copy'; // eslint-disable-line no-param-reassign
     return false;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -70,11 +70,10 @@ class Dropzone extends React.Component {
     e.stopPropagation();
     
     try {
-      e.dataTransfer.dropEffect = 'copy'; // eslint-disable-line no-param-reassign		      
-    } catch (e) {
-      // continue regardless of error  
-    }    
-    
+      e.dataTransfer.dropEffect = 'copy'; // eslint-disable-line no-param-reassign
+    } catch (err) {
+      // continue regardless of error
+    }
     return false;
   }
 


### PR DESCRIPTION
Dragging an item into the dropzone area causes JS errors in the hover state (though dropping the file works, and the file is successfully uploaded. It may be the case that MS browsers don't really support dropEffect in the way that we'd like it to:

https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/5184459/

The simplest solution is to remove the "dropEffect" line entirely. A future version might attempt some sort of feature detection before trying to set the dropEffect value.
