### PR TITLE
Allow string array's for accept argument

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -331,7 +331,10 @@ Dropzone.propTypes = {
 
   inputProps: React.PropTypes.object, // Pass additional attributes to the <input type="file"/> tag
   multiple: React.PropTypes.bool, // Allow dropping multiple files
-  accept: React.PropTypes.string, // Allow specific types of files. See https://github.com/okonet/attr-accept for more information
+  accept: React.PropTypes.oneOfType([  // Allow specific types of files. See https://github.com/okonet/attr-accept for more information
+    React.PropTypes.string,
+    React.PropTypes.arrayOf(React.PropTypes.string)
+  ]),
   name: React.PropTypes.string, // name attribute for the input tag
   maxSize: React.PropTypes.number,
   minSize: React.PropTypes.number

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -79,6 +79,15 @@ describe('Dropzone', () => {
       expect(component.find('input').attr('accept')).toEqual('image/jpeg');
     });
 
+    it('applies the accept prop to the child input as a string', () => {
+      const component = render(
+        <Dropzone className="my-dropzone" accept={['image/jpeg', 'image/png']} />
+      );
+      expect(component.find('.my-dropzone').attr()).not.toContain('accept');
+      expect(Object.keys(component.find('input').attr())).toContain('accept');
+      expect(component.find('input').attr('accept')).toEqual('image/jpeg,image/png');
+    });
+
     it('applies the name prop to the child input', () => {
       const component = render(
         <Dropzone className="my-dropzone" name="test-file-input" />


### PR DESCRIPTION
As [`attr-accept`][1] can handle array's as well; and this library simply passes the argument trough; I don't see any reason to leave this one out of the `PropTypes`. 

```js
accept({
    name: 'my file.json',
    type: 'application/json'
}, 'application/json,video/*') // => true

accept({
    name: 'my file.json',
    type: 'application/json'
}, ['application/json', 'video/*']) // => true
```

[1]: https://github.com/okonet/attr-accept#usage