### PR TITLE
Remove filetype check for preview (with specs fixed)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ class Dropzone extends React.Component {
     this.isFileDialogActive = false;
 
     fileList.forEach((file) => {
-      if (!disablePreview && accepts(file, 'image/*')) {
+      if (!disablePreview) {
         file.preview = window.URL.createObjectURL(file); // eslint-disable-line no-param-reassign
       }
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -542,13 +542,14 @@ describe('Dropzone', () => {
   });
 
   describe('preview', () => {
-    it('should not generate previews for non-images', () => {
+    it('should generate previews for non-images', () => {
       const dropSpy = spy();
       const dropzone = mount(
         <Dropzone onDrop={dropSpy} />
       );
       dropzone.simulate('drop', { dataTransfer: { files } });
-      expect(Object.keys(dropSpy.firstCall.args[0][0])).not.toContain('preview');
+      expect(Object.keys(dropSpy.firstCall.args[0][0])).toContain('preview');
+      expect(dropSpy.firstCall.args[0][0].preview).toContain('data://file1.pdf');
     });
 
     it('should generate previews for images', () => {


### PR DESCRIPTION
I went ahead and fixed the spec as requested here: https://github.com/okonet/react-dropzone/pull/322

This allows preview of PDFs and other files (a feature that used to exist, but was removed.) 