### PR TITLE
fix(onClick): don't swallow click events when disableClick is true

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -137,9 +137,9 @@ class Dropzone extends React.Component {
   }
 
   onClick(e) {
-    e.stopPropagation();
     const { onClick, disableClick } = this.props;
     if (!disableClick) {
+      e.stopPropagation();
       this.open();
       if (onClick) {
         onClick.call(this, e);

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -159,6 +159,18 @@ describe('Dropzone', () => {
       expect(onClickOuterSpy.callCount).toEqual(0);
       expect(onClickInnerSpy.callCount).toEqual(1);
     });
+
+    it('should invoke onClick on the wrapper if disableClick is set', () => {
+      const onClickOuterSpy = spy();
+      const component = mount(
+        <div onClick={onClickOuterSpy}>
+          <Dropzone disableClick />
+        </div>
+      );
+
+      component.find('Dropzone').simulate('click');
+      expect(onClickOuterSpy.callCount).toEqual(1);
+    });
   });
 
   describe('drag-n-drop', () => {


### PR DESCRIPTION
Scenario that I have is that list items are drop targets but users can also select items in the list by clicking on them. In 3.9.1 click events are not being received by the list items as they are swallowed by the dropzone.

Let me know if you would like anything changed, thanks.