### PR TITLE
Ignore Drag'n'drop elements that are not files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ class Dropzone extends React.Component {
     this.isFileDialogActive = false;
 
     fileList.forEach((file) => {
-      if (file instanceof window.DataTransferItem) {
+      if (!(file instanceof window.File)) {
         return;
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,10 @@ class Dropzone extends React.Component {
     this.isFileDialogActive = false;
 
     fileList.forEach((file) => {
+      if (file instanceof window.DataTransferItem) {
+        return;
+      }
+
       if (!disablePreview) {
         file.preview = window.URL.createObjectURL(file); // eslint-disable-line no-param-reassign
       }

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -6,6 +6,7 @@ const Dropzone = require(process.env.NODE_ENV === 'production' ? '../dist/index'
 
 let files;
 let images;
+let other;
 
 describe('Dropzone', () => {
 
@@ -25,6 +26,10 @@ describe('Dropzone', () => {
       size: 2345,
       type: 'image/jpeg'
     }];
+
+    other = [
+      new DataTransferItem({ kind: 'string', type: 'plain/text' })
+    ];
   });
 
   describe('basics', () => {
@@ -314,6 +319,18 @@ describe('Dropzone', () => {
       dropzone.simulate('drop', { dataTransfer: { files } });
       expect(dropzone.state().isDragActive).toEqual(false);
       expect(dropzone.state().isDragReject).toEqual(false);
+    });
+
+    it('should ignore non-files', () => {
+      const dropzone = mount(
+        <Dropzone
+          onDrop={dropSpy}
+          multiple
+        />
+      );
+
+      dropzone.simulate('drop', { dataTransfer: { files: other } });
+      expect(dropSpy.firstCall.args[0]).toHaveLength(0);
     });
 
     it('should take all dropped files if multiple is true', () => {

--- a/testSetup.js
+++ b/testSetup.js
@@ -5,3 +5,8 @@ global.window.URL = {
     return 'data://' + arg.name;
   }
 };
+
+global.window.DataTransferItem = function DataTransferItem(arg) {
+  this.kind = arg.kind;
+  this.type = arg.type;
+};


### PR DESCRIPTION
Fixes an issue where we combine `Dropzone` with other
elements that handle Drag'n'drop, like [react-sortable].

When combining these libraries, the `onDrop` event of
`Dropzone` gets triggered and tried to make a preview
of something that was not a file, throwing an exception.

[react-sortable]: https://github.com/cheton/react-sortable