### PR TITLE
Feature: Expose acceptedFiles and rejectedFiles to children

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-react-dropzone [![Build Status](https://travis-ci.org/okonet/react-dropzone.svg?branch=master)](https://travis-ci.org/okonet/react-dropzone) [![npm version](https://badge.fury.io/js/react-dropzone.svg)](https://badge.fury.io/js/react-dropzone) [![codecov](https://codecov.io/gh/okonet/react-dropzone/branch/master/graph/badge.svg)](https://codecov.io/gh/okonet/react-dropzone) [![OpenCollective](https://opencollective.com/react-dropzone/backers/badge.svg)](#backers) 
+react-dropzone [![Build Status](https://travis-ci.org/okonet/react-dropzone.svg?branch=master)](https://travis-ci.org/okonet/react-dropzone) [![npm version](https://badge.fury.io/js/react-dropzone.svg)](https://badge.fury.io/js/react-dropzone) [![codecov](https://codecov.io/gh/okonet/react-dropzone/branch/master/graph/badge.svg)](https://codecov.io/gh/okonet/react-dropzone) [![OpenCollective](https://opencollective.com/react-dropzone/backers/badge.svg)](#backers)
 [![OpenCollective](https://opencollective.com/react-dropzone/sponsors/badge.svg)](#sponsors)
 
 
@@ -77,14 +77,16 @@ You have a third option : providing a function that returns the component's chil
 
 ```
 <Dropzone>
-  {({ isDragActive, isDragReject }) => {
+  {({ isDragActive, isDragReject, acceptedFiles, rejectedFiles }) => {
     if (isDragActive) {
       return "This file is authorized";
     }
     if (isDragReject) {
       return "This file is not authorized";
     }
-    return "Try dropping some files";
+    return acceptedFiles.length || rejectedFiles.length
+      ? `Accepted ${acceptedFiles.length}, rejected ${rejectedFiles.length} files`
+      : "Try dropping some files";
   }}
 </Dropzone>
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-react-dropzone [![Build Status](https://travis-ci.org/okonet/react-dropzone.svg?branch=master)](https://travis-ci.org/okonet/react-dropzone) [![npm version](https://badge.fury.io/js/react-dropzone.svg)](https://badge.fury.io/js/react-dropzone) [![codecov](https://codecov.io/gh/okonet/react-dropzone/branch/master/graph/badge.svg)](https://codecov.io/gh/okonet/react-dropzone) [![OpenCollective](https://opencollective.com/react-dropzone/backers/badge.svg)](#backers)
+react-dropzone [![Build Status](https://travis-ci.org/okonet/react-dropzone.svg?branch=master)](https://travis-ci.org/okonet/react-dropzone) [![npm version](https://badge.fury.io/js/react-dropzone.svg)](https://badge.fury.io/js/react-dropzone) [![codecov](https://codecov.io/gh/okonet/react-dropzone/branch/master/graph/badge.svg)](https://codecov.io/gh/okonet/react-dropzone) [![OpenCollective](https://opencollective.com/react-dropzone/backers/badge.svg)](#backers) 
 [![OpenCollective](https://opencollective.com/react-dropzone/sponsors/badge.svg)](#sponsors)
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,13 +9,6 @@ const supportMultiple = (typeof document !== 'undefined' && document && document
   true;
 
 class Dropzone extends React.Component {
-  static renderChildren(children, isDragActive, isDragReject) {
-    if (typeof children === 'function') {
-      return children({ isDragActive, isDragReject });
-    }
-    return children;
-  }
-
   constructor(props, context) {
     super(props, context);
     this.onClick = this.onClick.bind(this);
@@ -28,7 +21,9 @@ class Dropzone extends React.Component {
     this.fileAccepted = this.fileAccepted.bind(this);
     this.isFileDialogActive = false;
     this.state = {
-      isDragActive: false
+      isDragActive: false,
+      acceptedFiles: [],
+      rejectedFiles: []
     };
   }
 
@@ -140,7 +135,9 @@ class Dropzone extends React.Component {
     // Reset drag state
     this.setState({
       isDragActive: false,
-      isDragReject: false
+      isDragReject: false,
+      acceptedFiles,
+      rejectedFiles
     });
   }
 
@@ -190,6 +187,13 @@ class Dropzone extends React.Component {
     this.isFileDialogActive = true;
     this.fileInputEl.value = null;
     this.fileInputEl.click();
+  }
+
+  renderChildren = (children) => {
+    if (typeof children === 'function') {
+      return children(this.state);
+    }
+    return children;
   }
 
   render() {
@@ -298,7 +302,7 @@ class Dropzone extends React.Component {
         onDragLeave={this.onDragLeave}
         onDrop={this.onDrop}
       >
-        {Dropzone.renderChildren(children, isDragActive, isDragReject)}
+        {this.renderChildren(children)}
         <input
           {...inputProps/* expand user provided inputProps first so inputAttributes override them */}
           {...inputAttributes}

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -352,6 +352,21 @@ describe('Dropzone', () => {
       expect(dropzone.state().isDragReject).toEqual(false);
     });
 
+    it('should expose acceptedFiles and rejectedFiles to children', () => {
+      const dropzone = mount(
+        <Dropzone
+          accept="image/*"
+          multiple={false}
+        >
+          {({ acceptedFiles, rejectedFiles }) => JSON.stringify([acceptedFiles, rejectedFiles])}
+        </Dropzone>
+      );
+      dropzone.simulate('drop', { dataTransfer: { files: images } });
+      expect(dropzone.text()).toEqual(JSON.stringify([images.slice(0, 1), []]));
+      dropzone.simulate('drop', { dataTransfer: { files } });
+      expect(dropzone.text()).toEqual(JSON.stringify([[], files.slice(0, 1)]));
+    });
+
     it('should take all dropped files if multiple is true', () => {
       const dropzone = mount(
         <Dropzone


### PR DESCRIPTION

**What kind of change does this PR introduce?**

- [ ] bugfix
- [x] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

Allow use accepted files and rejected files as props in children components.

```js
<Dropzone accept="image/*">
  {({ acceptedFiles }) => (acceptedFiles.length && <img src={acceptedFiles[0].preview} />)};
</Dropzone>
```