### PR TITLE
fix: Don't display bogus Firefox drag types as rejected

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -206,7 +206,7 @@ class Dropzone extends React.Component {
   }
 
   fileAccepted(file) {
-    return accepts(file, this.props.accept);
+    return file.type === 'application/x-moz-file' || accepts(file, this.props.accept);
   }
 
   fileMatchSize(file) {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -599,6 +599,30 @@ describe('Dropzone', () => {
       expect(dropRejectedSpy.callCount).toEqual(0);
     });
 
+    it('accepts a dropped image when Firefox provides a bogus file type', () => {
+      const dropzone = mount(
+        <Dropzone
+          onDrop={dropSpy}
+          onDropAccepted={dropAcceptedSpy}
+          onDropRejected={dropRejectedSpy}
+          accept="image/*"
+        />
+      );
+      const bogusImages = [{
+        name: 'bogus.gif',
+        size: 1234,
+        type: 'application/x-moz-file'
+      }];
+
+      dropzone.simulate('drop', { dataTransfer: { files: bogusImages } });
+      expect(dropSpy.callCount).toEqual(1);
+      expect(dropSpy.firstCall.args[0]).toHaveLength(1);
+      expect(dropSpy.firstCall.args[1]).toHaveLength(0);
+      expect(dropAcceptedSpy.callCount).toEqual(1);
+      expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(1);
+      expect(dropRejectedSpy.callCount).toEqual(0);
+    });
+
     it('accepts all dropped files and images when no accept prop is specified', () => {
       const dropzone = mount(
         <Dropzone


### PR DESCRIPTION
Since Firefox always returns a type of 'application/x-moz-file', until https://bugzilla.mozilla.org/show_bug.cgi?id=1342057 is implemented correctly on their side, the best we can do is treat that type as always accepted. A false positive is better than a false negative in this case, and brings behavior parity with Safari, which does not support file types at all.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [X] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [X] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [X] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Provide a workaround for https://github.com/okonet/react-dropzone/issues/362 that leads to less user confusion.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**
