### PR TITLE
Updated readme to also include reject styling options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ React.render(<DropzoneDemo />, document.body);
 Reacting to user input
 =====
 
-By default, the component picks up some default styling to get you started. You can customize `<Dropzone>` by specifying a `style` and `activeStyle` which is applied when a file is dragged over the zone. You can also specify `className` and `activeClassName` if you would rather style using CSS.
+By default, the component picks up some default styling to get you started. You can customize `<Dropzone>` by specifying a `style`, `activeStyle` or `rejectStyle` which is applied when a file is dragged over the zone. You can also specify `className`,  `activeClassName` or `rejectClassName` if you would rather style using CSS.
 
 You have a third option : providing a function that returns the component's children.
 


### PR DESCRIPTION
Updated readme to also include reject styling options.
The readme only included the active styling options. Now the reject styling options rejectClassName and rejectStyle are also in the readme.

**What kind of change does this PR introduce?**

- [ ] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [x] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**
When configuring react-dropzone for my project, i spent 30 minutes searching for rejectClassName. Now i added this to the readme so the next developer doesnt have to search that long.

**Does this PR introduce a breaking change?**
no

**Other information**
no