### PR TITLE
Handle changes in the accept setting mid-drag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -224,7 +224,7 @@ class Dropzone extends React.Component {
   }
 
   allFilesAccepted(files) {
-    return files.every(file => this.fileAccepted(file));
+    return files.every(this.fileAccepted);
   }
 
   /**

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -372,6 +372,19 @@ describe('Dropzone', () => {
       expect(dropzone.state().isDragReject).toEqual(true);
     });
 
+    it('should set proper dragActive state if accept prop changes mid-drag', () => {
+      const dropzone = mount(
+        <Dropzone accept="image/*" />
+      );
+      dropzone.simulate('dragEnter', { dataTransfer: { files: images } });
+      expect(dropzone.state().isDragActive).toEqual(true);
+      expect(dropzone.state().isDragReject).toEqual(false);
+
+      dropzone.setProps({ accept: 'text/*' });
+      expect(dropzone.state().isDragActive).toEqual(false);
+      expect(dropzone.state().isDragReject).toEqual(true);
+    });
+
     it('should expose state to children', () => {
       const dropzone = mount(
         <Dropzone accept="image/*">

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -6,6 +6,10 @@ const Dropzone = require(process.env.NODE_ENV === 'production' ? '../dist/index'
 
 let files;
 let images;
+const classConfig = {
+  activeClassName: 'test_active',
+  rejectClassName: 'test_reject'
+};
 
 describe('Dropzone', () => {
 
@@ -332,57 +336,59 @@ describe('Dropzone', () => {
 
     it('should set proper dragActive state on dragEnter', () => {
       const dropzone = mount(
-        <Dropzone />
+        <Dropzone {...classConfig} />
       );
       dropzone.simulate('dragEnter', { dataTransfer: { files } });
-      expect(dropzone.state().isDragActive).toEqual(true);
-      expect(dropzone.state().isDragReject).toEqual(false);
+      expect(dropzone.hasClass(classConfig.activeClassName)).toEqual(true);
+      expect(dropzone.hasClass(classConfig.rejectClassName)).toEqual(false);
     });
 
     it('should set proper dragReject state on dragEnter', () => {
       const dropzone = mount(
-        <Dropzone accept="image/*" />
+        <Dropzone {...classConfig} accept="image/*" />
       );
       dropzone.simulate('dragEnter', { dataTransfer: { files: files.concat(images) } });
-      expect(dropzone.state().isDragActive).toEqual(false);
-      expect(dropzone.state().isDragReject).toEqual(true);
+      expect(dropzone.hasClass(classConfig.activeClassName)).toEqual(false);
+      expect(dropzone.hasClass(classConfig.rejectClassName)).toEqual(true);
     });
 
     it('should set proper dragActive state if multiple is false', () => {
       const dropzone = mount(
         <Dropzone
+          {...classConfig}
           accept="image/*"
           multiple={false}
         />
       );
       dropzone.simulate('dragEnter', { dataTransfer: { files } });
-      expect(dropzone.state().isDragActive).toEqual(false);
-      expect(dropzone.state().isDragReject).toEqual(true);
+      expect(dropzone.hasClass(classConfig.activeClassName)).toEqual(false);
+      expect(dropzone.hasClass(classConfig.rejectClassName)).toEqual(true);
     });
 
     it('should set proper dragActive state if multiple is false', () => {
       const dropzone = mount(
         <Dropzone
+          {...classConfig}
           accept="image/*"
           multiple={false}
         />
       );
       dropzone.simulate('dragEnter', { dataTransfer: { files: images } });
-      expect(dropzone.state().isDragActive).toEqual(true);
-      expect(dropzone.state().isDragReject).toEqual(true);
+      expect(dropzone.hasClass(classConfig.activeClassName)).toEqual(true);
+      expect(dropzone.hasClass(classConfig.rejectClassName)).toEqual(true);
     });
 
     it('should set proper dragActive state if accept prop changes mid-drag', () => {
       const dropzone = mount(
-        <Dropzone accept="image/*" />
+        <Dropzone {...classConfig} accept="image/*" />
       );
       dropzone.simulate('dragEnter', { dataTransfer: { files: images } });
-      expect(dropzone.state().isDragActive).toEqual(true);
-      expect(dropzone.state().isDragReject).toEqual(false);
+      expect(dropzone.hasClass(classConfig.activeClassName)).toEqual(true);
+      expect(dropzone.hasClass(classConfig.rejectClassName)).toEqual(false);
 
       dropzone.setProps({ accept: 'text/*' });
-      expect(dropzone.state().isDragActive).toEqual(false);
-      expect(dropzone.state().isDragReject).toEqual(true);
+      expect(dropzone.hasClass(classConfig.activeClassName)).toEqual(false);
+      expect(dropzone.hasClass(classConfig.rejectClassName)).toEqual(true);
     });
 
     it('should expose state to children', () => {
@@ -410,7 +416,7 @@ describe('Dropzone', () => {
       const DragActiveComponent = () => <p>Active</p>;
       const ChildComponent = () => <p>Child component content</p>;
       const dropzone = mount(
-        <Dropzone>
+        <Dropzone {...classConfig}>
           {({ isDragActive, isDragReject }) => {
             if (isDragReject) {
               return 'Rejected';
@@ -426,12 +432,12 @@ describe('Dropzone', () => {
       dropzone.simulate('dragEnter', { dataTransfer: { files } });
       // make sure we handle any duplicate dragEnter events that the browser may send us
       dropzone.simulate('dragEnter', { dataTransfer: { files } });
-      expect(dropzone.state().isDragActive).toEqual(true);
-      expect(dropzone.state().isDragReject).toEqual(false);
+      expect(dropzone.hasClass(classConfig.activeClassName)).toEqual(true);
+      expect(dropzone.hasClass(classConfig.rejectClassName)).toEqual(false);
 
       dropzone.simulate('dragLeave', { dataTransfer: { files } });
-      expect(dropzone.state().isDragActive).toEqual(false);
-      expect(dropzone.state().isDragReject).toEqual(false);
+      expect(dropzone.hasClass(classConfig.activeClassName)).toEqual(false);
+      expect(dropzone.hasClass(classConfig.rejectClassName)).toEqual(false);
     });
   });
 
@@ -455,17 +461,18 @@ describe('Dropzone', () => {
     it('should reset the dragActive/dragReject state', () => {
       const dropzone = mount(
         <Dropzone
+          {...classConfig}
           onDrop={dropSpy}
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
         />
       );
       dropzone.simulate('dragEnter', { dataTransfer: { files } });
-      expect(dropzone.state().isDragActive).toEqual(true);
-      expect(dropzone.state().isDragReject).toEqual(false);
+      expect(dropzone.hasClass(classConfig.activeClassName)).toEqual(true);
+      expect(dropzone.hasClass(classConfig.rejectClassName)).toEqual(false);
       dropzone.simulate('drop', { dataTransfer: { files } });
-      expect(dropzone.state().isDragActive).toEqual(false);
-      expect(dropzone.state().isDragReject).toEqual(false);
+      expect(dropzone.hasClass(classConfig.activeClassName)).toEqual(false);
+      expect(dropzone.hasClass(classConfig.rejectClassName)).toEqual(false);
     });
 
     it('should add valid files to rejected files on a multple drop when multiple false', () => {
@@ -890,6 +897,7 @@ describe('Dropzone', () => {
         innerDropRejectedSpy = spy();
         outerDropzone = mount(
           <Dropzone
+            {...classConfig}
             onDrop={outerDropSpy}
             onDropAccepted={outerDropAcceptedSpy}
             onDropRejected={outerDropRejectedSpy}
@@ -904,8 +912,8 @@ describe('Dropzone', () => {
 
       it('does dragEnter on both dropzones', () => {
         innerDropzone.simulate('dragEnter', { dataTransfer: { files: images } });
-        expect(outerDropzone.state().isDragActive).toEqual(true);
-        expect(outerDropzone.state().isDragReject).toEqual(false);
+        expect(outerDropzone.hasClass(classConfig.activeClassName)).toEqual(true);
+        expect(outerDropzone.hasClass(classConfig.rejectClassName)).toEqual(false);
         expect(innerDropzone.find(InnerDragAccepted).exists()).toEqual(true);
         expect(innerDropzone.find(InnerDragRejected).exists()).toEqual(false);
       });
@@ -934,8 +942,8 @@ describe('Dropzone', () => {
         expect(outerDropAcceptedSpy.firstCall.args[0]).toHaveLength(2);
         expect(outerDropRejectedSpy.callCount).toEqual(1);
         expect(outerDropRejectedSpy.firstCall.args[0]).toHaveLength(1);
-        expect(outerDropzone.state().isDragActive).toEqual(false);
-        expect(outerDropzone.state().isDragReject).toEqual(false);
+        expect(outerDropzone.hasClass(classConfig.activeClassName)).toEqual(false);
+        expect(outerDropzone.hasClass(classConfig.rejectClassName)).toEqual(false);
       });
     });
   });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
When changing the `accept` prop for the component mid-drag, the component did not reflect the change until you happened to enter/leave another element. This PR updates the `isDragActive` state at the timing of the prop change, using `componentWillReceiveProps`, so the state will be updated right away.

In my use case, I was implementing a fullscreen dropzone as described in the documentation, and changed the accept type depending on which region of the page was hovered (which I achieved with a custom `onDragOver` handler). I had set custom classes with `activeClassName`/`rejectClassName`, but they would not reflect the updated `accept` setting until I dragged out and in again.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**
