### PR TITLE
Adjust timing around onClick/onDrag* events in IE11/Edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
   "contributors": [
     "Andrey Okonetchnikov <andrey@okonet.ru> (http://okonet.ru)",
     "Mike Olson <me@mwolson.org>",
-    "Param Aggarwal"
+    "Param Aggarwal",
+    "Tyler Waters <tyler.waters@gmail.com>"
   ],
   "license": "MIT",
   "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -193,10 +193,15 @@ class Dropzone extends React.Component {
     const { onClick, disableClick } = this.props
     if (!disableClick) {
       evt.stopPropagation()
-      this.open()
+
       if (onClick) {
         onClick.call(this, evt)
       }
+
+      // in IE11/Edge the file-browser dialog is blocking, ensure this is behind setTimeout
+      // this is so react can handle state changes in the onClick prop above above
+      // see: https://github.com/okonet/react-dropzone/issues/450
+      setTimeout(this.open.bind(this), 0)
     }
   }
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -175,11 +175,14 @@ describe('Dropzone', () => {
   })
 
   describe('onClick', () => {
-    it('should call `open` method', () => {
+    it('should call `open` method', done => {
       const dropzone = mount(<Dropzone />)
       spy(dropzone.instance(), 'open')
       dropzone.simulate('click')
-      expect(dropzone.instance().open.callCount).toEqual(1)
+      setTimeout(() => {
+        expect(dropzone.instance().open.callCount).toEqual(1)
+        done()
+      }, 0)
     })
 
     it('should not call `open` if disableClick prop is true', () => {
@@ -189,13 +192,16 @@ describe('Dropzone', () => {
       expect(dropzone.instance().open.callCount).toEqual(0)
     })
 
-    it('should call `onClick` callback if provided', () => {
+    it('should call `onClick` callback if provided', done => {
       const clickSpy = spy()
       const dropzone = mount(<Dropzone onClick={clickSpy} />)
       spy(dropzone.instance(), 'open')
       dropzone.simulate('click')
-      expect(dropzone.instance().open.callCount).toEqual(1)
-      expect(clickSpy.callCount).toEqual(1)
+      setTimeout(() => {
+        expect(dropzone.instance().open.callCount).toEqual(1)
+        expect(clickSpy.callCount).toEqual(1)
+        done()
+      }, 0)
     })
 
     it('should reset the value of input', () => {
@@ -206,12 +212,15 @@ describe('Dropzone', () => {
       expect(dropzone.render().find('input').attr('value')).toBeUndefined()
     })
 
-    it('should trigger click even on the input', () => {
+    it('should trigger click even on the input', done => {
       const dropzone = mount(<Dropzone />)
       const clickSpy = spy(dropzone.instance().fileInputEl, 'click')
       dropzone.simulate('click')
       dropzone.simulate('click')
-      expect(clickSpy.callCount).toEqual(2)
+      setTimeout(() => {
+        expect(clickSpy.callCount).toEqual(2)
+        done()
+      }, 0)
     })
 
     it('should not invoke onClick on the wrapper', () => {
@@ -247,12 +256,15 @@ describe('Dropzone', () => {
       expect(onClickOuterSpy.callCount).toEqual(1)
     })
 
-    it('should invoke inputProps onClick if provided', () => {
+    it('should invoke inputProps onClick if provided', done => {
       const inputPropsClickSpy = spy()
       const component = mount(<Dropzone inputProps={{ onClick: inputPropsClickSpy }} />)
 
       component.find('Dropzone').simulate('click')
-      expect(inputPropsClickSpy.callCount).toEqual(1)
+      setTimeout(() => {
+        expect(inputPropsClickSpy.callCount).toEqual(1)
+        done()
+      }, 0)
     })
   })
 
@@ -811,19 +823,22 @@ describe('Dropzone', () => {
       // Test / invoke the click event
       spy(component.instance(), 'open')
       component.simulate('click')
-      expect(component.instance().open.callCount).toEqual(1)
 
-      // Simulated DOM event - onfocus
-      document.body.addEventListener('focus', () => {})
-      const evt = document.createEvent('HTMLEvents')
-      evt.initEvent('focus', false, true)
-      document.body.dispatchEvent(evt)
-
-      // setTimeout to match the event callback from actual Component
       setTimeout(() => {
-        expect(onCancelSpy.callCount).toEqual(1)
-        done()
-      }, 300)
+        expect(component.instance().open.callCount).toEqual(1)
+
+        // Simulated DOM event - onfocus
+        document.body.addEventListener('focus', () => {})
+        const evt = document.createEvent('HTMLEvents')
+        evt.initEvent('focus', false, true)
+        document.body.dispatchEvent(evt)
+
+        // setTimeout to match the event callback from actual Component
+        setTimeout(() => {
+          expect(onCancelSpy.callCount).toEqual(1)
+          done()
+        }, 300)
+      }, 0)
     })
   })
 


### PR DESCRIPTION
Fixes #450

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

^^ had to fix a few tests to be async with the introduction on a `setTimeout` in the click handler.

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

Please see the issue, #450 for most of the reasoning.  Executive summary:  

In IE11/Edge the file browser dialogue will block code running.  A timeout is necessary here so that `setState` calls in `onClick` and `onDragRejected` won't conflict when batched together.

**Does this PR introduce a breaking change?**

No.

**Other information**

There was an unrelated code style fix that sorta just happened -- see the very bottom of this diff.