### PR TITLE
Set autocomplete="off" on input attribute

### DIFF
--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Dropzone basics should render children 1`] = `"<div class=\\"\\" style=\\"width: 200px; height: 200px; border-width: 2px; border-color: #666; border-style: dashed; border-radius: 5px;\\"><p>some content</p><input type=\\"file\\" multiple=\\"\\" style=\\"display: none;\\"></div>"`;
+exports[`Dropzone basics should render children 1`] = `"<div class=\\"\\" style=\\"width: 200px; height: 200px; border-width: 2px; border-color: #666; border-style: dashed; border-radius: 5px;\\"><p>some content</p><input type=\\"file\\" multiple=\\"\\" autocomplete=\\"off\\" style=\\"display: none;\\"></div>"`;
 
-exports[`Dropzone document drop protection does not prevent stray drops when preventDropOnDocument is false 1`] = `"<div class=\\"\\" style=\\"width: 200px; height: 200px; border-width: 2px; border-color: #666; border-style: dashed; border-radius: 5px;\\"><input type=\\"file\\" multiple=\\"\\" style=\\"display: none;\\"></div>"`;
+exports[`Dropzone document drop protection does not prevent stray drops when preventDropOnDocument is false 1`] = `"<div class=\\"\\" style=\\"width: 200px; height: 200px; border-width: 2px; border-color: #666; border-style: dashed; border-radius: 5px;\\"><input type=\\"file\\" multiple=\\"\\" autocomplete=\\"off\\" style=\\"display: none;\\"></div>"`;
 
-exports[`Dropzone document drop protection installs hooks to prevent stray drops from taking over the browser window 1`] = `"<div class=\\"\\" style=\\"width: 200px; height: 200px; border-width: 2px; border-color: #666; border-style: dashed; border-radius: 5px;\\"><p>Content</p><input type=\\"file\\" multiple=\\"\\" style=\\"display: none;\\"></div>"`;
+exports[`Dropzone document drop protection installs hooks to prevent stray drops from taking over the browser window 1`] = `"<div class=\\"\\" style=\\"width: 200px; height: 200px; border-width: 2px; border-color: #666; border-style: dashed; border-radius: 5px;\\"><p>Content</p><input type=\\"file\\" multiple=\\"\\" autocomplete=\\"off\\" style=\\"display: none;\\"></div>"`;

--- a/src/index.js
+++ b/src/index.js
@@ -358,7 +358,8 @@ class Dropzone extends React.Component {
       style: { display: 'none' },
       multiple: supportMultiple && multiple,
       ref: this.setRefs,
-      onChange: this.onDrop
+      onChange: this.onDrop,
+      autoComplete: 'off'
     }
 
     if (name && name.length) {


### PR DESCRIPTION
Fixes #475.

Note that because `inputAttributes` is placed after user provided `inputProps` when they are merged, users will not be able to override this setting. Since, I can't imagine why someone would want this behavior, this way makes more sense and keeps the code clean.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
